### PR TITLE
Use toString(TermBuffer) overload for --print

### DIFF
--- a/src/nbonsai.nim
+++ b/src/nbonsai.nim
@@ -334,11 +334,7 @@ proc nbonsai(
 
   if print:
     deinitTernim()
-    var line = ""
-    for y in 0'u16..<tb.height:
-      line.toString tb.buf.toOpenArray(int(tb.width * y), int(tb.width * y.succ - 1))
-      stdout.writeLine line
-      line.setLen 0
+    stdout.writeLine toString(tb)
   else:
     discard getch()
     deinitTernim()


### PR DESCRIPTION
Overload added in https://github.com/Clyybber/ternim/commit/e262e0257428cff3384fd8f4ab0df22d33f450fe